### PR TITLE
Enable loadbalancer quotas

### DIFF
--- a/ci/roles/quota/defaults/main.yml
+++ b/ci/roles/quota/defaults/main.yml
@@ -28,3 +28,9 @@ test_compute_quota:
   ram: 5
   server_group_members: 5
   server_groups: 5
+test_loadbalancer_quota:
+  load_balancers: 5
+  health_monitors: 5
+  listeners: 5
+  pools: 5
+  members: 5

--- a/ci/roles/quota/tasks/main.yml
+++ b/ci/roles/quota/tasks/main.yml
@@ -79,6 +79,26 @@
       openstack.cloud.quota: "{{ test_compute_quota }}"
       register: quotas
 
+    - name: Set load_balancer quotas
+      openstack.cloud.quotas: "{{ test_load_balancer_quota }}"
+      register: quotas
+
+    - name: Assert changed
+      assert:
+        that: quotas is changed
+
+    - name: Assert field values
+      assert:
+        that: quotas.quotas.load_balancer[item.key] == item.value
+      loop: "{{ test_load_balancer_quota | dict2items }}"
+
+    - name: Set load_balancer quotas again
+      openstack.cloud.quota: "{{ test_load_balancer_quota }}"
+
+    - name: Assert not changed
+      assert:
+        that: quotas is not changed
+
     - name: Unset all quotas
       openstack.cloud.quota:
         state: absent
@@ -90,7 +110,7 @@
 
     - name: Set all quotas at once
       openstack.cloud.quota:
-        "{{ [test_network_quota, test_volume_quota, test_compute_quota] | combine }}"
+        "{{ [test_network_quota, test_volume_quota, test_compute_quota, test_load_balancer_quota] | combine }}"
       register: quotas
 
     - name: Assert changed
@@ -112,9 +132,13 @@
         that: quotas.quotas.compute[item.key] == item.value
       loop: "{{ test_compute_quota | dict2items }}"
 
+    - name: Assert load_balancer values
+      assert:
+        that: quotas.quotas.load_balancer[item.key] == item.value
+
     - name: Set all quotas at once again
       openstack.cloud.quota:
-        "{{ [test_network_quota, test_volume_quota, test_compute_quota] | combine }}"
+        "{{ [test_network_quota, test_volume_quota, test_compute_quota, test_load_balancer_quota] | combine }}"
       register: quotas
 
     - name: Assert not changed

--- a/plugins/modules/quota.py
+++ b/plugins/modules/quota.py
@@ -70,13 +70,14 @@ options:
         type: int
     l7_policies:
         description: The maximum amount of L7 policies you can create.
-        type: int 
+        type: int
     listeners:
         description: The maximum number of listeners you can create.
         type: int
     load_balancers:
         description: The maximum amount of load balancers you can create
         type: int
+        aliases: [loadbalancer]
     metadata_items:
        description: Number of metadata items allowed per instance.
        type: int
@@ -377,6 +378,8 @@ from collections import defaultdict
 
 
 class QuotaModule(OpenStackModule):
+    # TODO: Add missing network quota options 'check_limit', and 'l7_policies'
+    #       to argument_spec, DOCUMENTATION and RETURN docstrings
     argument_spec = dict(
         backup_gigabytes=dict(type='int'),
         backups=dict(type='int'),
@@ -398,7 +401,7 @@ class QuotaModule(OpenStackModule):
         key_pairs=dict(type='int', no_log=False),
         l7_policies=dict(type='int'),
         listeners=dict(type='int'),
-        load_balancers=dict(type='int'),
+        load_balancers=dict(type='int', aliases=['loadbalancer']),
         metadata_items=dict(type='int'),
         members=dict(type='int'),
         name=dict(required=True),

--- a/plugins/modules/quota.py
+++ b/plugins/modules/quota.py
@@ -20,6 +20,10 @@ options:
     backups:
         description: Maximum number of backups allowed.
         type: int
+    check_limit:
+        description: 
+          - Flag to check the network quota usage before setting the new limit.
+        type: bool
     cores:
         description: Maximum number of CPU's per project.
         type: int
@@ -37,6 +41,9 @@ options:
         type: int
     groups:
         description: Number of groups that are allowed for the project
+        type: int
+    health_monitors:
+        description: Maximum number of health monitors that can be created.
         type: int
     injected_file_content_bytes:
         description:
@@ -60,6 +67,12 @@ options:
         type: int
     key_pairs:
         description: Number of key pairs to allow.
+        type: int
+    l7_policies:
+        description: The maximum amount of L7 policies you can create.
+        type: int 
+    listeners:
+        description: The maximum number of listeners you can create.
         type: int
     load_balancers:
         description: The maximum amount of load balancers you can create
@@ -231,8 +244,23 @@ quotas:
             description: Network service quotas
             type: dict
             contains:
+                check_limit:
+                    description: Flag to check the quota usage before setting 
+                      the new limit.
+                    type: bool
                 floating_ips:
                     description: Number of floating IP's to allow.
+                    type: int
+                health_monitors:
+                    description: Maximum number of health monitors that can be 
+                      created.
+                    type: int
+                l7_policies:
+                    description: The maximum amount of L7 policies you can 
+                       create.
+                    type: int 
+                listeners:
+                    description: The maximum number of listeners you can create.
                     type: int
                 load_balancers:
                     description: The maximum amount of load balancers one can
@@ -312,6 +340,9 @@ quotas:
                 server_groups: 10,
             network:
                 floating_ips: 50,
+                health_monitors: 10,
+                l7_policies: 10,
+                listeners: 10,
                 load_balancers: 10,
                 networks: 10,
                 pools: 10,
@@ -337,12 +368,10 @@ from collections import defaultdict
 
 
 class QuotaModule(OpenStackModule):
-    # TODO: Add missing network quota options 'check_limit', 'health_monitors',
-    #       'l7_policies', 'listeners' to argument_spec, DOCUMENTATION and
-    #       RETURN docstrings
     argument_spec = dict(
         backup_gigabytes=dict(type='int'),
         backups=dict(type='int'),
+        check_limit=dict(type='bool'),
         cores=dict(type='int'),
         fixed_ips=dict(type='int'),
         floating_ips=dict(
@@ -350,6 +379,7 @@ class QuotaModule(OpenStackModule):
                                  'network_floating_ips']),
         gigabytes=dict(type='int'),
         groups=dict(type='int'),
+        health_monitors=dict(type='int'),
         injected_file_content_bytes=dict(type='int',
                                          aliases=['injected_file_size']),
         injected_file_path_bytes=dict(type='int',
@@ -357,6 +387,8 @@ class QuotaModule(OpenStackModule):
         injected_files=dict(type='int'),
         instances=dict(type='int'),
         key_pairs=dict(type='int', no_log=False),
+        l7_policies=dict(type='int'),
+        listeners=dict(type='int'),
         load_balancers=dict(type='int', aliases=['loadbalancer']),
         metadata_items=dict(type='int'),
         name=dict(required=True),

--- a/plugins/modules/quota.py
+++ b/plugins/modules/quota.py
@@ -399,7 +399,7 @@ class QuotaModule(OpenStackModule):
         key_pairs=dict(type='int', no_log=False),
         l7_policies=dict(type='int'),
         listeners=dict(type='int'),
-        load_balancers=dict(type='int'), aliases=['loadbalancer']),
+        load_balancers=dict(type='int', aliases=['loadbalancer']),
         metadata_items=dict(type='int'),
         members=dict(type='int'),
         name=dict(required=True),
@@ -472,6 +472,7 @@ class QuotaModule(OpenStackModule):
         else:
             self.warn('Network service is not supported by your cloud.'
                       ' Ignoring network quotas.')
+
         quota['compute'] = self.conn.compute.get_quota_set(project.id)
 
         return quota


### PR DESCRIPTION
Extends quota support to cover all loadbalancer related quotas exposed by the loadbalancer quota in [openstacksdk](https://github.com/openstack/openstacksdk/blob/master/openstack/load_balancer/v2/quota.py)

These are exposed for the purpose of adding loadbalancer quota support in our openstack-config.

Functionality here is prerequiste for ansible-collection-openstack loadbalancer quota support.

